### PR TITLE
use golang as builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:experimental
 ARG base_image
 
-FROM concourse/golang-builder AS builder
+FROM golang AS builder
 RUN apt update && apt upgrade -y
 WORKDIR /src
 COPY go.mod /src/go.mod


### PR DESCRIPTION
## Changes proposed in this pull request:

- Switch from concourse golang image to general golang image
- Necessary because concoure golang image is now built with wolfi which uses apk instead of apt

## security considerations

Switching builder image
